### PR TITLE
feat(web): create page to informe that user is activated

### DIFF
--- a/web/src/adapters/authentication.js
+++ b/web/src/adapters/authentication.js
@@ -24,6 +24,22 @@ async function registerUser({ firstname, lastname, email, password, userType }) 
   }
 }
 
+async function activateUser(token) {
+  const requestBody = {
+    method: "PATCH",
+    headers: {
+      authorization: `Bearer ${token}`,
+    },
+  };
+
+  try {
+    const request = await fetch(`${BASE_URL}register`, requestBody);
+    return request.status === 204;
+  } catch {
+    return false;
+  }
+}
+
 async function loginUser({ email, password }) {
   const requestBody = {
     method: "POST",
@@ -57,4 +73,4 @@ async function loginUser({ email, password }) {
   }
 }
 
-export { loginUser, registerUser };
+export { activateUser, loginUser, registerUser };

--- a/web/src/tests/acceptance/views/authentication/ActivationView.spec.js
+++ b/web/src/tests/acceptance/views/authentication/ActivationView.spec.js
@@ -1,0 +1,59 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createRouter, createWebHistory } from "vue-router";
+
+import { activateUser } from "@/adapters/authentication.js";
+import ActivationView from "@/views/authentication/ActivationView.vue";
+
+vi.mock("@/adapters/authentication.js", () => ({
+  activateUser: vi.fn(),
+}));
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [
+    { path: "/authentication/login", component: { template: "<div>Login</div>" } },
+    { path: "/authentication/register", component: { template: "<div>Register</div>" } },
+  ],
+});
+
+describe("Acceptance | Views | Authentication | Activation", () => {
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    router.push({ path: "/", query: { token: "mock-token" } });
+    await router.isReady();
+  });
+
+  it("should render success message when activation succeeds", async () => {
+    // given
+    activateUser.mockResolvedValue(true);
+
+    // when
+    const wrapper = mount(ActivationView, {
+      global: { plugins: [router] },
+    });
+
+    await flushPromises();
+
+    expect(activateUser).toHaveBeenCalledWith("mock-token");
+    expect(wrapper.text()).toContain("Votre compte a bien été activé");
+    expect(wrapper.find("a").attributes("href")).toBe("/authentication/login");
+  });
+
+  it("should render error message when activation fails", async () => {
+    // given
+    activateUser.mockResolvedValue(false);
+
+    // when
+    const wrapper = mount(ActivationView, {
+      global: { plugins: [router] },
+    });
+
+    await flushPromises();
+
+    // then
+    expect(activateUser).toHaveBeenCalledWith("mock-token");
+    expect(wrapper.text()).toContain("Votre compte n'a pas pu être activé");
+    expect(wrapper.find("a").attributes("href")).toBe("/authentication/register");
+  });
+});

--- a/web/src/tests/unit/adapters/authentication.spec.js
+++ b/web/src/tests/unit/adapters/authentication.spec.js
@@ -49,7 +49,7 @@ describe("Unit |  Adapters | Authentication", () => {
       expect(result).toBe(false);
     });
 
-    it("should return false if an error occured", async () => {
+    it("should return false if an error occurred", async () => {
       // given
       const user = {
         firstname: "John",
@@ -65,6 +65,54 @@ describe("Unit |  Adapters | Authentication", () => {
 
       // then
       expect(resultPromise).toBe(false);
+    });
+  });
+
+  describe("#activateUser", () => {
+    it("should return true if request response with 204", async () => {
+      // given
+      const token = "abc123";
+      vi.spyOn(global, "fetch").mockResolvedValue({
+        status: 204,
+      });
+
+      // when
+      const result = await authentication.activateUser(token);
+
+      // then
+      expect(fetch).toHaveBeenCalledWith("/api/authentication/register", {
+        method: "PATCH",
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      });
+      expect(result).toBe(true);
+    });
+
+    it("should return false if request response code is not 204", async () => {
+      // given
+      const token = "abc123";
+      vi.spyOn(global, "fetch").mockResolvedValue({
+        status: 400,
+      });
+
+      // when
+      const result = await authentication.activateUser(token);
+
+      // then
+      expect(result).toBe(false);
+    });
+
+    it("should return false if an error occurred", async () => {
+      // given
+      const token = "abc123";
+      vi.spyOn(global, "fetch").mockRejectedValue(new Error("Network error"));
+
+      // when
+      const result = await authentication.activateUser(token);
+
+      // then
+      expect(result).toBe(false);
     });
   });
 
@@ -116,7 +164,7 @@ describe("Unit |  Adapters | Authentication", () => {
       expect(token).toBeNull();
     });
 
-    it("should return message if an error occured", async () => {
+    it("should return message if an error occurred", async () => {
       // given
       const user = {
         email: "john.doe@example.net",

--- a/web/src/views/authentication/ActivationView.vue
+++ b/web/src/views/authentication/ActivationView.vue
@@ -1,0 +1,30 @@
+<script setup>
+import { onMounted, ref } from "vue";
+import { useRoute } from "vue-router";
+
+import { activateUser } from "@/adapters/authentication.js";
+const route = useRoute();
+const isActivated = ref(false);
+
+onMounted(async () => {
+  const token = route.query.token;
+  if (await activateUser(token)) {
+    isActivated.value = true;
+  }
+});
+</script>
+
+<template>
+<h1>Activation de votre compte</h1>
+  <div v-if="isActivated">
+    <p>Votre compte a bien été activé. Vous pouvez vous connecter.</p>
+    <RouterLink to="/authentication/login">Accéder à la page de connexion</RouterLink>
+  </div>
+  <div v-else>
+    <p>Votre compte n'a pas pu être activé. Une erreur est survenue. Réessayez de vous enregistrer. Si le problème persiste, contactez un administrateur.</p>
+    <RouterLink to="/authentication/register">Accéder à la page d'inscription</RouterLink>
+  </div>
+</template>
+
+<style scoped>
+</style>


### PR DESCRIPTION
This pull request introduces user account activation functionality to the authentication flow. The main changes include implementing the activation logic in the authentication adapter, creating a new activation view, and adding comprehensive unit and acceptance tests to ensure correct behavior.

**Authentication logic and API integration:**

* Added `activateUser` function to `authentication.js` to handle user account activation via a PATCH request with a token.
* Exported `activateUser` from `authentication.js` for use in other modules.

**User interface:**

* Created `ActivationView.vue` to display activation success or error messages and provide navigation links based on activation outcome.

**Testing:**

* Added acceptance tests for activation flow in `ActivationView.spec.js`, covering both success and failure scenarios.
* Added unit tests for `activateUser` to verify correct API calls and response handling, including error cases.