### PR TITLE
fix: Fix the status code accepted for register

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -3,6 +3,7 @@ import express from "express";
 import path from "path";
 
 import authentication from "./src/authentication/routes.js";
+import { logger } from "./src/shared/logger.js";
 import { healthCheckRoute } from "./src/shared/routes/health-check-route.js";
 import userRoute from "./src/shared/routes/user-route.js";
 
@@ -11,8 +12,15 @@ const server = express();
 server.use(cors());
 server.use(express.json());
 server.use(express.static(path.join(process.cwd(), "dist")));
+server.use((req, res, next) => {
+  res.on("finish", () => {
+    logger.info(`${req.method} ${req.url} ${res.statusCode}`);
+  });
+  next();
+});
 server.use(healthCheckRoute);
 server.use(authentication);
 server.use(userRoute);
+
 
 export default server;

--- a/web/src/adapters/authentication.js
+++ b/web/src/adapters/authentication.js
@@ -18,7 +18,7 @@ async function registerUser({ firstname, lastname, email, password, userType }) 
   };
   try {
     const request = await fetch(`${BASE_URL}register`, requestBody);
-    return request.status === 200 ? true : false;
+    return request.status === 201;
   } catch {
     return false;
   }

--- a/web/src/tests/acceptance/views/authentication/RegisterView.spec.js
+++ b/web/src/tests/acceptance/views/authentication/RegisterView.spec.js
@@ -92,7 +92,7 @@ describe("Acceptance | Views | Authentication | Register View", () => {
     // given
     const passwordCharacters = "JedetenD-123";
     const mockFetch = vi.spyOn(globalThis, "fetch").mockResolvedValue({
-      status: 200,
+      status: 201,
       ok: true,
     });
 

--- a/web/src/tests/unit/adapters/authentication.spec.js
+++ b/web/src/tests/unit/adapters/authentication.spec.js
@@ -19,7 +19,7 @@ describe("Unit |  Adapters | Authentication", () => {
         userType: USER_TYPES.MASTER_GUIDE_DOG.type,
       };
       vi.spyOn(global, "fetch").mockResolvedValue({
-        status: 200,
+        status: 201,
       });
 
       // when


### PR DESCRIPTION
This pull request introduces a logging middleware to the Express server and updates the user registration flow to expect a `201 Created` status code instead of `200 OK`. It also updates related tests to match the new expected status code.

**Server enhancements:**

* Added a request logging middleware to the Express server using the `logger` from `src/shared/logger.js`, which logs HTTP method, URL, and response status for each request. [[1]](diffhunk://#diff-9a833c35e47340f0693af8115da337dff6f2a7576b805dc884d3437b8fec1228R6) [[2]](diffhunk://#diff-9a833c35e47340f0693af8115da337dff6f2a7576b805dc884d3437b8fec1228R15-R25)

**User registration flow updates:**

* Changed the user registration adapter (`registerUser` in `authentication.js`) to return success only if the server responds with a `201` status code, aligning with RESTful standards for resource creation.

**Test updates:**

* Updated acceptance and unit tests to expect a `201` status code for successful user registration instead of `200`. (`RegisterView.spec.js`, `authentication.spec.js`) [[1]](diffhunk://#diff-72281b52b27dfa96bce1f92a98896677bd7ac85c37472e211478ed059e410f99L95-R95) [[2]](diffhunk://#diff-d9649d680d187548d6c0f614f7d07c7f41283ddb7accbb8f07631ba60a4f5e60L22-R22)