### PR TITLE
tech(api): add the support for dogs

### DIFF
--- a/api/db/database-builder/factory/buildDog.js
+++ b/api/db/database-builder/factory/buildDog.js
@@ -7,7 +7,7 @@ async function buildDog({
 }) {
   const [values] = await knex("dogs").insert({
     name, type, userId,
-  }).return("*");
+  }).returning("*");
 
   return values;
 }

--- a/api/db/database-builder/factory/buildDog.js
+++ b/api/db/database-builder/factory/buildDog.js
@@ -1,0 +1,15 @@
+import { knex } from "../../knex-database-connection.js";
+
+async function buildDog({
+  userId = null,
+  name = "Uno",
+  type = "Labrador",
+}) {
+  const [values] = await knex("dogs").insert({
+    name, type, userId,
+  }).return("*");
+
+  return values;
+}
+
+export { buildDog };

--- a/api/db/database-builder/index.js
+++ b/api/db/database-builder/index.js
@@ -1,8 +1,10 @@
 import { buildUser } from "./factory/build-user.js";
+import { buildDog } from "./factory/buildDog.js";
 
 const databaseBuilder = {
   factory: {
     buildUser,
+    buildDog,
   },
 };
 

--- a/api/db/migrations/20250907115822_create-dogs-table.js
+++ b/api/db/migrations/20250907115822_create-dogs-table.js
@@ -1,0 +1,26 @@
+const TABLE_NAME = "dogs";
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+async function up(knex) {
+  await knex.schema.createTable(TABLE_NAME, (table) => {
+    table.increments("id").primary();
+    table.string("name").notNullable();
+    table.string("type");
+    table.integer("userId").references("id").inTable("users").onDelete("CASCADE");
+    table.timestamp("created_at").defaultTo(knex.fn.now());
+    table.timestamp("updated_at").defaultTo(knex.fn.now());
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+async function down(knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { down, up };

--- a/api/db/seeds/users.js
+++ b/api/db/seeds/users.js
@@ -15,6 +15,21 @@ async function createUserWithMasterType() {
   });
 }
 
+async function createUserWithDog() {
+  const { id } = await databaseBuilder.factory.buildUser({
+    firstname: "dog",
+    lastname: "master",
+    email: "dog.master@example.net",
+    hashedPassword,
+    lastLoggedAt: new Date(),
+  });
+  await databaseBuilder.factory.buildDog({
+    userId: id,
+    name: "Dogo",
+    type: "Labrador",
+  });
+}
+
 async function createUserWithCompanionType() {
   await databaseBuilder.factory.buildUser({
     firstname: "User",
@@ -51,6 +66,7 @@ async function seed() {
   console.log("seeding users...");
   await createUserWithCompanionType();
   await createUserWithMasterType();
+  await createUserWithDog();
   await createUserNotActive();
   await createUserWithShouldChangePassword();
 }

--- a/api/tests/setup.js
+++ b/api/tests/setup.js
@@ -2,14 +2,19 @@ import { afterAll, afterEach, beforeEach, vi } from "vitest";
 
 import { knex } from "../db/knex-database-connection.js";
 
+
 beforeEach(async () => {
-  const tables = await knex("pg_tables")
-    .select("tablename")
-    .where("schemaname", "public");
-  for (const { tablename } of tables) {
-    await knex(tablename).truncate();
-  }
+  await knex.raw("TRUNCATE TABLE " +
+        (await knex("pg_tables")
+          .select("tablename")
+          .where("schemaname", "public")
+          .pluck("tablename"))
+          .map((t) => `"${t}"`)
+          .join(", ") +
+        " RESTART IDENTITY CASCADE",
+  );
 });
+
 
 afterEach(function() {
   vi.restoreAllMocks();


### PR DESCRIPTION
This pull request introduces support for managing dog records in the database, including migration, factory, and seeding updates. The main changes are the addition of a new `dogs` table, a factory for creating dog records, and updates to the seed logic to create users with associated dogs.

**Database schema changes:**

* Added a migration file `20250907115822_create-dogs-table.js` to create the `dogs` table with fields for `id`, `name`, `type`, `userId` (foreign key referencing `users`), and timestamps.

**Factory and data creation:**

* Added `buildDog` factory function in `buildDog.js` for creating dog records using Knex, and registered it in the main `databaseBuilder` factory index. [[1]](diffhunk://#diff-50a48ccf3fdbc54635b77869c1843788426b2cef6e53928121a5d5b0dac10daaR1-R15) [[2]](diffhunk://#diff-44fe78ab4466bfd87bc09d0740ed5c69152d6e8821618852aedc18dd92633ee4R2-R7)

**Seed data updates:**

* Added `createUserWithDog` function to create a user and an associated dog, and invoked it in the main `seed` function to ensure the database is seeded with a user who owns a dog. [[1]](diffhunk://#diff-bd50c9f44622aff6a33e0b05ec34fd00e4faf29c7b5ca2c367dd26b9872eb260R18-R32) [[2]](diffhunk://#diff-bd50c9f44622aff6a33e0b05ec34fd00e4faf29c7b5ca2c367dd26b9872eb260R69)